### PR TITLE
Add subtle blue to gold gradient sitewide

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -94,7 +94,7 @@
     .footer__bar { border-top: 1px solid #2b2b2b; padding: 14px 0; color: #9ca3af; font-size: 13px; }
   </style>
 </head>
-<body>
+<body class="site-bg--blue-gold">
   <!-- Header -->
   <header class="header" role="banner">
     <div class="container header__row">

--- a/adminportal.html
+++ b/adminportal.html
@@ -73,7 +73,7 @@
 .dot.rose{background:#d28b7b}
   </style>
 </head>
-<body>
+<body class="site-bg--blue-gold">
   <header>
     <div class="container header__row">
       <div class="brand"><a href="/">Culet Diamonds — Admin</a></div>

--- a/animations.css
+++ b/animations.css
@@ -1,5 +1,24 @@
 /* Global animation and loading styles */
 
+/* Sitewide subtle blue → gold gradient background */
+html.site-bg--blue-gold,
+body.site-bg--blue-gold {
+  background:
+    linear-gradient(120deg, rgba(15,46,110,0.10) 0%, rgba(176,141,87,0.10) 100%),
+    radial-gradient(800px 600px at 15% -10%, rgba(176,141,87,0.18), rgba(176,141,87,0) 60%),
+    radial-gradient(900px 700px at 85% 110%, rgba(15,46,110,0.16), rgba(15,46,110,0) 60%),
+    linear-gradient(180deg, #fafafa 0%, #ffffff 40%, #f6f6f6 100%);
+  background-attachment: fixed;
+}
+
+/* Optional dark blue background variant */
+body.site-bg--blue-black {
+  background:
+    radial-gradient(900px 700px at 85% 120%, rgba(15, 46, 110, 0.16), rgba(15, 46, 110, 0) 60%),
+    linear-gradient(180deg, #0b0e16 0%, #0a0a0a 100%);
+  background-attachment: fixed;
+}
+
 /* Placeholder block */
 .ph {
   position: relative;

--- a/engagement-rings.html
+++ b/engagement-rings.html
@@ -150,7 +150,7 @@
     .inkable:hover::before { opacity: 1; }
   </style>
 </head>
-<body>
+<body class="site-bg--blue-gold">
   <!-- Header -->
   <header class="header" role="banner">
     <div class="container header__row">

--- a/index.html
+++ b/index.html
@@ -59,17 +59,6 @@
       color: var(--text);
     }
 
-    /* Blue → Gold subtle background */
-    html.site-bg--blue-gold,
-    body.site-bg--blue-gold {
-      background:
-        linear-gradient(120deg, rgba(15,46,110,0.10) 0%, rgba(176,141,87,0.10) 100%),
-        radial-gradient(800px 600px at 15% -10%, rgba(176,141,87,0.18), rgba(176,141,87,0) 60%),
-        radial-gradient(900px 700px at 85% 110%, rgba(15,46,110,0.16), rgba(15,46,110,0) 60%),
-        linear-gradient(180deg, #fafafa 0%, #ffffff 40%, #f6f6f6 100%);
-      background-attachment: fixed;
-    }
-
     body {
       font-family: Manrope, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
       line-height: 1.6;
@@ -80,16 +69,6 @@
     a { color: inherit; text-decoration: none; }
     a:visited { color: inherit; }
     a:hover, a:active, a:focus { color: inherit; }
-
-    /* Minimalistic site backgrounds */
-
-    body.site-bg--blue-black {
-      background:
-        radial-gradient(900px 700px at 85% 120%, rgba(15, 46, 110, 0.16), rgba(15, 46, 110, 0) 60%),
-        linear-gradient(180deg, #0b0e16 0%, #0a0a0a 100%);
-      background-attachment: fixed;
-    }
-
 
     /* Header */
     .header {


### PR DESCRIPTION
## Summary
- add reusable blue→gold gradient background to shared stylesheet
- apply gradient to About Us, Engagement Rings, and Admin Portal pages
- remove inline gradient styles from index.html

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68adb4b257ac83299496297a253c0098