### PR TITLE
Make blue‑to‑gold gradient background more prominent

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -23,7 +23,7 @@
       --shadow: 0 10px 30px rgba(0,0,0,.06);
     }
     * { box-sizing: border-box; }
-    html, body { margin: 0; padding: 0; background: var(--bg); color: var(--text); }
+    html, body { margin: 0; padding: 0; background: transparent; color: var(--text); }
     body { font-family: Manrope, system-ui, sans-serif; line-height: 1.6; overflow-x: hidden; }
     h1, h2, h3 { font-family: "Cormorant Garamond", serif; color: #0b1d49; letter-spacing: .02em; }
     a { color: inherit; text-decoration: none; }
@@ -71,7 +71,7 @@
     .inkable:hover::before { opacity: 1; }
 
     /* Page banner */
-    .banner { background: linear-gradient(180deg, #f6f8ff 0%, #ffffff 100%); border-bottom: 1px solid var(--border); padding: clamp(28px, 6vw, 80px) 0; text-align: center; }
+    .banner { background: transparent; border-bottom: 1px solid var(--border); padding: clamp(28px, 6vw, 80px) 0; text-align: center; }
     .banner h1 { font-size: clamp(28px, 5vw, 56px); margin: 0; }
     .banner p { color: #4b5563; margin: 8px 0 0; font-size: clamp(14px, 1.6vw, 18px); }
 
@@ -94,7 +94,7 @@
     .footer__bar { border-top: 1px solid #2b2b2b; padding: 14px 0; color: #9ca3af; font-size: 13px; }
   </style>
 </head>
-<body>
+<body class="site-bg--blue-gold">
   <!-- Header -->
   <header class="header" role="banner">
     <div class="container header__row">

--- a/adminportal.html
+++ b/adminportal.html
@@ -14,7 +14,7 @@
       --radius:12px; --shadow:0 10px 30px rgba(0,0,0,.06); --max:1100px; --pad:clamp(14px,2vw,24px);
     }
     *{box-sizing:border-box}
-    html,body{margin:0;padding:0;background:var(--bg);color:#111}
+    html,body{margin:0;padding:0;background:transparent;color:#111}
     body{font-family:Manrope,system-ui,sans-serif;line-height:1.6}
     h1,h2,h3{font-family:"Cormorant Garamond",serif;color:#0b1d49;letter-spacing:.02em}
     a{text-decoration:none;color:inherit}
@@ -73,7 +73,7 @@
 .dot.rose{background:#d28b7b}
   </style>
 </head>
-<body>
+<body class="site-bg--blue-gold">
   <header>
     <div class="container header__row">
       <div class="brand"><a href="/">Culet Diamonds — Admin</a></div>

--- a/animations.css
+++ b/animations.css
@@ -1,5 +1,24 @@
 /* Global animation and loading styles */
 
+/* Sitewide subtle blue → gold gradient background */
+html.site-bg--blue-gold,
+body.site-bg--blue-gold {
+  background:
+    linear-gradient(120deg, rgba(15,46,110,0.40) 0%, rgba(176,141,87,0.40) 100%),
+    radial-gradient(800px 600px at 15% -10%, rgba(176,141,87,0.65), rgba(176,141,87,0) 60%),
+    radial-gradient(900px 700px at 85% 110%, rgba(15,46,110,0.60), rgba(15,46,110,0) 60%),
+    linear-gradient(180deg, #fafafa 0%, #ffffff 40%, #f6f6f6 100%);
+  background-attachment: fixed;
+}
+
+/* Optional dark blue background variant */
+body.site-bg--blue-black {
+  background:
+    radial-gradient(900px 700px at 85% 120%, rgba(15, 46, 110, 0.16), rgba(15, 46, 110, 0) 60%),
+    linear-gradient(180deg, #0b0e16 0%, #0a0a0a 100%);
+  background-attachment: fixed;
+}
+
 /* Placeholder block */
 .ph {
   position: relative;

--- a/engagement-rings.html
+++ b/engagement-rings.html
@@ -48,7 +48,7 @@
     .nav__indicator { position: absolute; bottom: 0; height: 2px; width: 0; background: var(--accent); border-radius: 2px; transition: left .28s cubic-bezier(.2,.8,.2,1), width .28s cubic-bezier(.2,.8,.2,1); pointer-events: none; }
 
     /* Page head */
-    .banner { background: #ffffff; padding: clamp(24px, 5vw, 64px) 0; text-align: center; }
+    .banner { background: transparent; padding: clamp(24px, 5vw, 64px) 0; text-align: center; }
     .banner h1 { margin: 0; font-size: clamp(28px, 5vw, 48px); text-align: center; }
     .banner .banner__desc {
       margin: 10px auto 0;
@@ -150,7 +150,7 @@
     .inkable:hover::before { opacity: 1; }
   </style>
 </head>
-<body>
+<body class="site-bg--blue-gold">
   <!-- Header -->
   <header class="header" role="banner">
     <div class="container header__row">

--- a/index.html
+++ b/index.html
@@ -59,17 +59,6 @@
       color: var(--text);
     }
 
-    /* Blue → Gold subtle background */
-    html.site-bg--blue-gold,
-    body.site-bg--blue-gold {
-      background:
-        linear-gradient(120deg, rgba(15,46,110,0.10) 0%, rgba(176,141,87,0.10) 100%),
-        radial-gradient(800px 600px at 15% -10%, rgba(176,141,87,0.18), rgba(176,141,87,0) 60%),
-        radial-gradient(900px 700px at 85% 110%, rgba(15,46,110,0.16), rgba(15,46,110,0) 60%),
-        linear-gradient(180deg, #fafafa 0%, #ffffff 40%, #f6f6f6 100%);
-      background-attachment: fixed;
-    }
-
     body {
       font-family: Manrope, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
       line-height: 1.6;
@@ -80,16 +69,6 @@
     a { color: inherit; text-decoration: none; }
     a:visited { color: inherit; }
     a:hover, a:active, a:focus { color: inherit; }
-
-    /* Minimalistic site backgrounds */
-
-    body.site-bg--blue-black {
-      background:
-        radial-gradient(900px 700px at 85% 120%, rgba(15, 46, 110, 0.16), rgba(15, 46, 110, 0) 60%),
-        linear-gradient(180deg, #0b0e16 0%, #0a0a0a 100%);
-      background-attachment: fixed;
-    }
-
 
     /* Header */
     .header {
@@ -322,7 +301,7 @@
     .hero {
       position: relative;
       padding: clamp(36px, 8vw, 100px) 0;
-      background: rgba(255, 255, 255, 0.72);
+      background: transparent;
       border-bottom: none;
     }
 
@@ -689,7 +668,7 @@
     /* Newsletter */
     .newsletter {
       border-top: 1px solid var(--border);
-      background: rgba(255,255,255,0.8);
+      background: transparent;
     }
 
     .newsletter__row {


### PR DESCRIPTION
## Summary
- boost opacity of shared blue→gold gradient
- remove solid backgrounds from hero, newsletter, and page banners so gradient shows everywhere
- clear default page backgrounds so gradient appears on admin portal as well

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adb4b257ac83299496297a253c0098