### PR TITLE
fix: limit best seller card width on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@
     }
     @media (max-width: 1200px) { #bestGrid { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
     @media (max-width: 900px)  { #bestGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
-    @media (max-width: 560px)  { #bestGrid { grid-template-columns: 1fr; } }
+    @media (max-width: 560px)  { #bestGrid { grid-template-columns: repeat(auto-fit, minmax(240px, 280px)); } }
 
     /* Center and slightly shrink the Best Sellers CTA */
     #bestGrid .card > .btn:last-child { align-self: center; }


### PR DESCRIPTION
## Summary
- keep best seller cards from stretching full width on small screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aed7af0e108329bacc2c300c128d71