### PR TITLE
style: use white for secondary headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     :root {
       --bg: #ffffff;
       --text: #121212;
-      --muted: #6b7280;
+      --muted: #ffffff;
       --accent: #b08d57;
       --accent-ink: #0f2e6e;
       --border: #e7e7e7;


### PR DESCRIPTION
## Summary
- change homepage muted color to white for section eyebrow headings

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aed7e20ba08329a82d74aed32f7328