### PR TITLE
Add admin portal support for homepage images

### DIFF
--- a/adminportal.html
+++ b/adminportal.html
@@ -128,6 +128,29 @@
       </div>
     </section>
 
+    <section id="siteImagesPanel" class="panel hidden" aria-live="polite" style="margin-top:16px">
+      <div class="panel__head"><strong>Homepage Images</strong><span class="badge" id="imgStatus">Idle</span></div>
+      <div class="panel__body">
+        <p class="muted">Upload standalone images used on the homepage.</p>
+        <form id="siteImagesForm">
+          <div class="field">
+            <label for="titleImage">Title Image</label>
+            <input id="titleImage" type="file" accept="image/*">
+            <div id="titleThumb" class="thumb" style="margin-top:8px"></div>
+          </div>
+          <div class="field">
+            <label for="aboutImage">About Us Image</label>
+            <input id="aboutImage" type="file" accept="image/*">
+            <div id="aboutThumb" class="thumb" style="margin-top:8px"></div>
+          </div>
+          <div style="display:flex; gap:10px; margin-top:14px">
+            <button id="saveSiteImagesBtn" class="btn btn--dark" type="submit">Save Images</button>
+            <button id="reloadSiteImagesBtn" class="btn" type="button">Reload</button>
+          </div>
+        </form>
+      </div>
+    </section>
+
     <!-- Not admin notice -->
     <section id="notAdmin" class="panel hidden">
       <div class="panel__head"><strong>Access restricted</strong></div>
@@ -351,6 +374,8 @@
         loadRings();
         showHomepagePanel();
         loadHomepageConfig();
+        showSiteImagesPanel();
+        loadSiteImages();
       }else{
         authGate.classList.add('hidden');
         dash.classList.add('hidden');
@@ -608,6 +633,15 @@ resetBtn.addEventListener('click', ()=>{
     const reloadHomepageBtn = document.getElementById('reloadHomepageBtn');
     const hpStatus = document.getElementById('hpStatus');
 
+    const siteImagesPanel = document.getElementById('siteImagesPanel');
+    const titleImageInput = document.getElementById('titleImage');
+    const aboutImageInput = document.getElementById('aboutImage');
+    const titleThumb = document.getElementById('titleThumb');
+    const aboutThumb = document.getElementById('aboutThumb');
+    const saveSiteImagesBtn = document.getElementById('saveSiteImagesBtn');
+    const reloadSiteImagesBtn = document.getElementById('reloadSiteImagesBtn');
+    const imgStatus = document.getElementById('imgStatus');
+
     // Build a flat catalog of all items across collections
     async function fetchAllCatalog(){
       const result = []; // { id, title, collectionId, display }
@@ -734,11 +768,63 @@ resetBtn.addEventListener('click', ()=>{
       }
     }
 
+    async function loadSiteImages(){
+      imgStatus.textContent = 'Loading…';
+      try{
+        const snap = await getDoc(doc(db, 'config', 'site_images'));
+        if(snap.exists()){
+          const data = snap.data();
+          await resolveStorageBackground(titleThumb, data?.title?.path);
+          await resolveStorageBackground(aboutThumb, data?.about?.path);
+        }else{
+          titleThumb.style.backgroundImage = '';
+          aboutThumb.style.backgroundImage = '';
+        }
+      }catch(e){ console.warn('site images load failed', e); }
+      imgStatus.textContent = 'Idle';
+    }
+
+    async function saveSiteImages(e){
+      e.preventDefault();
+      imgStatus.textContent = 'Saving…';
+      const updates = {};
+      const pairs = [
+        ['title', titleImageInput.files[0]],
+        ['about', aboutImageInput.files[0]]
+      ];
+      try{
+        for(const [key, file] of pairs){
+          if(!file) continue;
+          const safe = file.name.replace(/[^a-zA-Z0-9._-]/g,'_');
+          const path = `site_images/${key}/${safe}`;
+          const storageRef = ref(storage, path);
+          await uploadBytesResumable(storageRef, file, { contentType: file.type });
+          const url = await getDownloadURL(storageRef);
+          updates[key] = { path, url };
+        }
+        if(Object.keys(updates).length){
+          await setDoc(doc(db, 'config', 'site_images'), updates, { merge:true });
+        }
+        imgStatus.textContent = 'Saved';
+        await loadSiteImages();
+      }catch(e){
+        console.error('site images save failed', e);
+        imgStatus.textContent = 'Error';
+        alert('Save failed: ' + (e?.message || e));
+      }finally{
+        setTimeout(()=> imgStatus.textContent = 'Idle', 1200);
+      }
+    }
+
+    function showSiteImagesPanel(){ siteImagesPanel.classList.remove('hidden'); }
+
     // Show homepage panel only for admins alongside dash
     function showHomepagePanel(){ homepagePanel.classList.remove('hidden'); }
 
     saveHomepageBtn?.addEventListener('click', saveHomepageConfig);
     reloadHomepageBtn?.addEventListener('click', loadHomepageConfig);
+    saveSiteImagesBtn?.addEventListener('click', saveSiteImages);
+    reloadSiteImagesBtn?.addEventListener('click', loadSiteImages);
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1267,6 +1267,49 @@
       cards.forEach(el => grid.appendChild(el));
     }
 
+    async function hydrateSiteImages() {
+      try {
+        const snap = await getDoc(doc(db, 'config', 'site_images'));
+        if (!snap.exists()) return;
+        const data = snap.data();
+        const heroEl = document.querySelector('.hero .ph');
+        if (data?.title?.path && heroEl) {
+          setFirebaseLoading(heroEl, true);
+          try {
+            const url = await getDownloadURL(ref(storage, data.title.path));
+            const img = new Image();
+            img.onload = () => {
+              heroEl.style.backgroundImage = `url('${url}')`;
+              heroEl.classList.add('is-loaded');
+              heroEl.classList.remove('ph--empty');
+              setFirebaseLoading(heroEl, false);
+            };
+            img.src = url;
+          } catch (e) {
+            setFirebaseLoading(heroEl, false);
+          }
+        }
+        const aboutMedia = document.querySelector('[aria-label="About Us image"]');
+        const aboutImg = aboutMedia?.querySelector('img');
+        if (data?.about?.path && aboutMedia && aboutImg) {
+          setFirebaseLoading(aboutMedia, true);
+          try {
+            const url = await getDownloadURL(ref(storage, data.about.path));
+            aboutImg.addEventListener('load', () => {
+              aboutMedia.classList.add('is-loaded');
+              aboutMedia.classList.remove('ph--empty');
+              setFirebaseLoading(aboutMedia, false);
+            }, { once: true });
+            aboutImg.src = url;
+          } catch (e) {
+            setFirebaseLoading(aboutMedia, false);
+          }
+        }
+      } catch (e) {
+        console.warn('site images hydrate failed', e);
+      }
+    }
+
     async function loadHomepage() {
       try {
         const cfgSnap = await getDoc(doc(db, 'config', 'homepage'));
@@ -1276,6 +1319,7 @@
       } catch (e) { console.error('Homepage config error', e); }
     }
 
+    hydrateSiteImages();
     loadHomepage();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- allow admins to upload standalone homepage images (title/about)
- display uploaded hero and about-us images on index

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68af0f22df9c8329b34a68782e9f9207