### PR TITLE
Reset navbar scroll to leftmost on load

### DIFF
--- a/aboutus.html
+++ b/aboutus.html
@@ -228,6 +228,7 @@
       const indicator = document.querySelector('.nav__indicator');
       const links = document.querySelectorAll('.nav__link');
       if(!nav || !indicator || !links.length) return;
+      nav.scrollLeft = 0;
       function moveIndicator(el){
         const navRect = nav.getBoundingClientRect();
         const rect = el.getBoundingClientRect();

--- a/bracelets.html
+++ b/bracelets.html
@@ -315,6 +315,7 @@
       const indicator = document.querySelector('.nav__indicator');
       const links = document.querySelectorAll('.nav__link');
       if(!nav || !indicator || !links.length) return;
+      nav.scrollLeft = 0;
       function moveIndicator(el){
         const navRect = nav.getBoundingClientRect();
         const rect = el.getBoundingClientRect();

--- a/diamonds.html
+++ b/diamonds.html
@@ -315,6 +315,7 @@
       const indicator = document.querySelector('.nav__indicator');
       const links = document.querySelectorAll('.nav__link');
       if(!nav || !indicator || !links.length) return;
+      nav.scrollLeft = 0;
       function moveIndicator(el){
         const navRect = nav.getBoundingClientRect();
         const rect = el.getBoundingClientRect();

--- a/earrings.html
+++ b/earrings.html
@@ -315,6 +315,7 @@
       const indicator = document.querySelector('.nav__indicator');
       const links = document.querySelectorAll('.nav__link');
       if(!nav || !indicator || !links.length) return;
+      nav.scrollLeft = 0;
       function moveIndicator(el){
         const navRect = nav.getBoundingClientRect();
         const rect = el.getBoundingClientRect();

--- a/engagement-rings.html
+++ b/engagement-rings.html
@@ -315,6 +315,7 @@
       const indicator = document.querySelector('.nav__indicator');
       const links = document.querySelectorAll('.nav__link');
       if(!nav || !indicator || !links.length) return;
+      nav.scrollLeft = 0;
       function moveIndicator(el){
         const navRect = nav.getBoundingClientRect();
         const rect = el.getBoundingClientRect();

--- a/estate-jewelry.html
+++ b/estate-jewelry.html
@@ -315,6 +315,7 @@
       const indicator = document.querySelector('.nav__indicator');
       const links = document.querySelectorAll('.nav__link');
       if(!nav || !indicator || !links.length) return;
+      nav.scrollLeft = 0;
       function moveIndicator(el){
         const navRect = nav.getBoundingClientRect();
         const rect = el.getBoundingClientRect();

--- a/index.html
+++ b/index.html
@@ -982,6 +982,7 @@
       const indicator = document.querySelector('.nav__indicator');
       const links = document.querySelectorAll('.nav__link');
       if (!nav || !indicator || !links.length) return;
+      nav.scrollLeft = 0;
 
       function moveIndicator(el) {
         const navRect = nav.getBoundingClientRect();

--- a/necklaces.html
+++ b/necklaces.html
@@ -315,6 +315,7 @@
       const indicator = document.querySelector('.nav__indicator');
       const links = document.querySelectorAll('.nav__link');
       if(!nav || !indicator || !links.length) return;
+      nav.scrollLeft = 0;
       function moveIndicator(el){
         const navRect = nav.getBoundingClientRect();
         const rect = el.getBoundingClientRect();

--- a/rings.html
+++ b/rings.html
@@ -315,6 +315,7 @@
       const indicator = document.querySelector('.nav__indicator');
       const links = document.querySelectorAll('.nav__link');
       if(!nav || !indicator || !links.length) return;
+      nav.scrollLeft = 0;
       function moveIndicator(el){
         const navRect = nav.getBoundingClientRect();
         const rect = el.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- Ensure navigation bar scroll position defaults to the left on page load across all site pages.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af14efccc4832993ea6dc246048fc2